### PR TITLE
Add Scheduled Transaction job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Install packages
@@ -72,6 +72,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: mysql2://127.0.0.1:3306
+          REDIS_URL: redis://127.0.0.1:6379
         run: |
           bin/rails db:test:prepare
           bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "thruster", require: false
 gem "bcrypt"
 gem "jwt"
 
+gem "sidekiq-cron"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    cronex (0.15.0)
+      tzinfo
+      unicode (>= 0.4.4.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -238,6 +241,8 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redis-client (0.25.2)
+      connection_pool
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -291,6 +296,17 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sidekiq (8.0.7)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
+    sidekiq-cron (2.3.1)
+      cronex (>= 0.13.0)
+      fugit (~> 1.8, >= 1.11.1)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6.5.0)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -324,6 +340,7 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode (0.4.4.5)
     unicode-display_width (3.1.5)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -365,6 +382,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rails-omakase
   rubocop-rspec
+  sidekiq-cron
   solid_cable
   solid_cache
   solid_queue

--- a/app/jobs/scheduled_transaction_job.rb
+++ b/app/jobs/scheduled_transaction_job.rb
@@ -1,0 +1,52 @@
+class ScheduledTransactionJob
+  include Sidekiq::Worker
+
+  def perform
+    ScheduledTransaction.where(active: true)
+                        .where(next_execute_at: ..Time.current)
+                        .find_each do |scheduled_tx|
+      begin
+        ActiveRecord::Base.transaction do
+          Rails.logger.info "Start create scheduled transactin ##{scheduled_tx.id}..."
+          transaction_user = User.find(scheduled_tx.user.id)
+          transaction_params = {
+            category_id: scheduled_tx.category_id,
+            currency_id: scheduled_tx.currency_id,
+            amount: scheduled_tx.amount,
+            description: scheduled_tx.description
+          }
+          service = TransactionCreateService.new(transaction_user, transaction_params)
+          service.call
+
+          next_time = calculate_next_execute_at(scheduled_tx)
+
+          if next_time.nil?
+            scheduled_tx.update!(active: false)
+            Rails.logger.info "Scheduled Transaction ##{scheduled_tx.id} was updated with active status false"
+          else
+            scheduled_tx.update!(next_execute_at: next_time)
+            Rails.logger.info "Scheduled Transaction ##{scheduled_tx.id} was updated with next_execute_at: #{next_time}"
+          end
+        end
+      rescue => e
+        Rails.logger.error "Unexpected Error on processing ScheduledTransaction ##{scheduled_tx.id}: #{e.message}"
+      end
+    end
+  end
+
+  def calculate_next_execute_at(scheduled_tx)
+    next_time = case scheduled_tx.frequency
+    when "once" then nil
+    when "daily" then scheduled_tx.next_execute_at + 1.day
+    when "weekly" then scheduled_tx.next_execute_at + 1.week
+    when "monthly" then scheduled_tx.next_execute_at + 1.month
+    else nil
+    end
+
+    if scheduled_tx.end_date && next_time && next_time > scheduled_tx.end_date
+      nil
+    else
+      next_time
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+Sidekiq::Cron::Job.create(
+  name: "ScheduledTransactionJob every 1 minute",
+  cron: "*/1 * * * *",
+  class: "ScheduledTransactionJob"
+)

--- a/spec/jobs/scheduled_transaction_job_spec.rb
+++ b/spec/jobs/scheduled_transaction_job_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+
+Sidekiq::Testing.inline!
+
+RSpec.describe ScheduledTransactionJob, type: :job do
+  let(:current_user) { create(:auth_user) }
+
+  before do
+    create_list(:scheduled_transaction, 3, next_execute_at: 1.minute.ago, active: true, user: current_user)
+    create_list(:scheduled_transaction, 2, next_execute_at: 1.day.from_now, active: true, user: current_user)
+    create_list(:scheduled_transaction, 2, next_execute_at: 1.minute.ago, active: false, user: current_user)
+  end
+
+  it 'processes only scheduled transactions that are active and due' do
+    expect {
+      described_class.perform_async
+    }.to change(Transaction, :count).by(3)
+  end
+
+  it 'updates next_execute_at appropriately' do
+    scheduled_transaction = create(:scheduled_transaction, :daily, next_execute_at: 1.minute.ago)
+    old_execute_date = scheduled_transaction.next_execute_at
+    described_class.perform_async
+    scheduled_transaction.reload
+
+    expect(scheduled_transaction.next_execute_at).to eq(old_execute_date + 1.day)
+  end
+
+  it 'updates active appropriately' do
+    scheduled_transaction = create(:scheduled_transaction, next_execute_at: 1.minute.ago, active: true)
+    described_class.perform_async
+    scheduled_transaction.reload
+
+    expect(scheduled_transaction.active).to be(false)
+  end
+end


### PR DESCRIPTION
Add Scheduled Transaction Job. Using Sidekiq Cron, run a job every minute to check scheduled transactions that should be executed, update their next_execute_at date and set their active status to false if the scheduled transaction should be deactivated and also add tests .