### PR TITLE
Added jsonapi-serializer for correct formatting of responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+/dump.rdb
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "bcrypt", "3.1.20"
 gem "jwt", "3.1.2"
 
 # --- APIs / Serialization ---
-gem "active_model_serializers", "0.10.15"
+gem "jsonapi-serializer", "2.2.0"
 gem "rack-cors", "3.0.0"
 
 # --- Background Jobs  ---

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,11 +44,6 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    active_model_serializers (0.10.15)
-      actionpack (>= 4.1)
-      activemodel (>= 4.1)
-      case_transform (>= 0.2)
-      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (8.0.2.1)
       activesupport (= 8.0.2.1)
       globalid (>= 0.3.6)
@@ -87,8 +82,6 @@ GEM
     brakeman (7.1.0)
       racc
     builder (3.3.0)
-    case_transform (0.2)
-      activesupport
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -125,7 +118,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.13.2)
-    jsonapi-renderer (0.2.2)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -326,13 +320,13 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  active_model_serializers (= 0.10.15)
   bcrypt (= 3.1.20)
   bootsnap (= 1.18.6)
   brakeman (= 7.1.0)
   debug (= 1.11.0)
   factory_bot_rails (= 6.5.0)
   faker (= 3.5.2)
+  jsonapi-serializer (= 2.2.0)
   jwt (= 3.1.2)
   mysql2 (~> 0.5, >= 0.5.6)
   puma (>= 6.6.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,22 @@ class ApplicationController < ActionController::API
 
   SECRET_KEY = Rails.application.secret_key_base
 
+  def render_jsonapi_response(collection, status: :ok, serializer: nil, include: nil, meta: {})
+    serializer ||= serializer_for(collection)
+    return unless serializer
+
+    options = build_serialization_options(collection, include, meta)
+    response = serializer.new(collection, **options).serializable_hash
+
+    render json: response, status: status
+  end
+
+  def render_jsonapi_error(resource, status: :unprocessable_content)
+    errors = normalize_errors(resource)
+
+    render json: errors_response(errors, status), status: status
+  end
+
   def encode_token(payload)
     exp = 1.day.from_now.to_i
     payload = payload.merge({ exp: exp })
@@ -34,8 +50,67 @@ class ApplicationController < ActionController::API
   end
 
   def authorized
-    unless !!current_user
-      render json: { message: "Please log in" }, status: :unauthorized
+    return if current_user
+
+    render_jsonapi_error("Please log in", status: :unauthorized)
+  end
+
+  private
+
+  def build_serialization_options(collection, include, meta)
+    options = { meta: meta }
+    options[:include] = include if include.present? && collection.present?
+
+    options
+  end
+
+  def normalize_errors(resource)
+    return resource if resource.is_a?(Array)
+    return [ resource ] if resource.is_a?(String)
+
+    [ "Unexpected error occurred" ]
+  end
+
+  def errors_response(errors, status)
+    code = status_code(status)
+    title = status_title(code)
+
+    {
+      errors: errors.map do |error_message|
+        {
+          status: code,
+          title: title,
+          detail: error_message
+        }
+      end
+    }
+  end
+
+  def serializer_for(collection)
+    collection_class = if collection.respond_to?(:to_ary)
+      collection.to_ary.first&.class
+    else
+      collection.class
     end
+
+    collection_class = "Default" if collection_class.nil?
+
+    serializer_name = "#{collection_class}Serializer"
+    serializer = serializer_name.safe_constantize
+
+    unless serializer
+      Rails.logger.error("Serializer not found for #{collection_class}")
+      render_jsonapi_error(nil, status: :internal_server_error)
+    end
+
+    serializer
+  end
+
+  def status_code(status)
+    Rack::Utils.status_code(status).to_s
+  end
+
+  def status_title(code)
+    Rack::Utils::HTTP_STATUS_CODES[code.to_i] || "Error"
   end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,28 +1,28 @@
 class AuthController < ApplicationController
-    skip_before_action :authorized, only: [ :login ]
+  skip_before_action :authorized, only: [ :login ]
 
-    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
-    def login
-        @user = User.find_by!(email: login_params[:email])
-        if @user.authenticate(login_params[:password])
-            @token = encode_token(user_id: @user.id)
-            render json: {
-                user: @user,
-                token: @token
-            }, status: :accepted
-        else
-            render json: { message: "Incorrect password" }, status: :unauthorized
-        end
+  def login
+    @user = User.find_by!(email: login_params[:email])
+    if @user.authenticate(login_params[:password])
+      @token = encode_token(user_id: @user.id)
+      render json: {
+        user: @user,
+        token: @token
+      }, status: :accepted
+    else
+      render_jsonapi_error("Incorrect password", status: :unauthorized)
     end
+  end
 
-    private
+  private
 
-    def login_params
-        params.expect(auth: [ :email, :password ])
-    end
+  def login_params
+    params.expect(auth: [ :email, :password ])
+  end
 
-    def render_not_found(exceptione)
-        render json: { message: "User doesn't exist" }, status: :unauthorized
-    end
+  def render_not_found(exceptione)
+    render_jsonapi_error("User doesn't exist", status: :unauthorized)
+  end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,7 +7,7 @@ class CategoriesController < ApplicationController
         default_categories = Category.where(user_id: nil)
         all_categories = default_categories + user_categories
 
-        render json: all_categories, status: :ok
+        render_jsonapi_response(all_categories)
     end
 
     def show
@@ -15,21 +15,21 @@ class CategoriesController < ApplicationController
                  .or(Category.where(id: params[:id], user_id: nil))
                  .first!
 
-        render json: category, status: :ok
+        render_jsonapi_response(category)
     end
 
     def create
         category = current_user.categories.new(category_params)
         category.save!
 
-        render json: category, status: :created
+        render_jsonapi_response(category, status: :created)
     end
 
     def update
         category = current_user.categories.find(params[:id])
         category.update!(category_params)
 
-        render json: category, status: :ok
+        render_jsonapi_response(category)
     end
 
     def destroy
@@ -42,11 +42,11 @@ class CategoriesController < ApplicationController
     private
 
     def render_not_found(exception)
-        render json: { error: exception.message }, status: :not_found
+        render_jsonapi_error(exception.message, status: :not_found)
     end
 
     def render_unprocessable_content(exception)
-        render json: { error: exception.record.errors.full_messages }, status: :unprocessable_content
+        render_jsonapi_error(exception.record.errors.full_messages, status: :unprocessable_content)
     end
 
     def category_params

--- a/app/controllers/currencies_controller.rb
+++ b/app/controllers/currencies_controller.rb
@@ -5,27 +5,27 @@ class CurrenciesController < ApplicationController
     def index
         currencies = Currency.all
 
-        render json: currencies, status: :ok
+        render_jsonapi_response(currencies)
     end
 
     def show
         currency = Currency.find(params[:id])
 
-        render json: currency, status: :ok
+        render_jsonapi_response(currency)
     end
 
     def create
         currency = Currency.new(currency_params)
         currency.save!
 
-        render json: currency, status: :created
+        render_jsonapi_response(currency, status: :created)
     end
 
     def update
         currency = Currency.find(params[:id])
         currency.update!(currency_params)
 
-        render json: currency, status: :ok
+        render_jsonapi_response(currency)
     end
 
     def destroy
@@ -38,11 +38,11 @@ class CurrenciesController < ApplicationController
     private
 
     def render_not_found(exception)
-        render json: { error: exception.message }, status: :not_found
+        render_jsonapi_error(exception.message, status: :not_found)
     end
 
     def render_unprocessable_content(exception)
-        render json: { error: exception.record.errors.full_messages }, status: :unprocessable_content
+        render_jsonapi_error(exception.record.errors.full_messages, status: :unprocessable_content)
     end
 
     def currency_params

--- a/app/controllers/scheduled_transactions_controller.rb
+++ b/app/controllers/scheduled_transactions_controller.rb
@@ -5,27 +5,27 @@ class ScheduledTransactionsController < ApplicationController
     def index
         scheduled_transactions = current_user.scheduled_transactions
 
-        render json: scheduled_transactions, status: :ok
+        render_jsonapi_response(scheduled_transactions)
     end
 
     def show
         scheduled_transaction = current_user.scheduled_transactions.find(params[:id])
 
-        render json: scheduled_transaction, status: :ok
+        render_jsonapi_response(scheduled_transaction)
     end
 
     def create
         scheduled_transaction = current_user.scheduled_transactions.new(scheduled_transaction_params)
         scheduled_transaction.save!
 
-        render json: scheduled_transaction, status: :created
+        render_jsonapi_response(scheduled_transaction, status: :created)
     end
 
     def update
         scheduled_transaction = current_user.scheduled_transactions.find(params[:id])
         service = ScheduledTransactionUpdateService.new(scheduled_transaction, scheduled_transaction_params)
 
-        render json: service.call, status: :ok
+        render_jsonapi_response(service.call)
     end
 
     def destroy
@@ -38,11 +38,11 @@ class ScheduledTransactionsController < ApplicationController
     private
 
     def render_not_found(exception)
-        render json: { error: exception.message }, status: :not_found
+        render_jsonapi_error(exception.message, status: :not_found)
     end
 
     def render_unprocessable_content(exception)
-        render json: { error: exception.record.errors.full_messages }, status: :unprocessable_content
+        render_jsonapi_error(exception.record.errors.full_messages, status: :unprocessable_content)
     end
 
     def scheduled_transaction_params

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -10,26 +10,26 @@ class TransactionsController < ApplicationController
         sort_param, sort_order = parse_sort_params(params[:sort])
         transactions = TransactionSortService.new(transactions, sort_param, sort_order).call if sort_param.present?
 
-        render json: transactions, status: :ok
+        render_jsonapi_response(transactions, include: [ :category, :currency ])
     end
 
     def show
         transaction = current_user.transactions.includes(:category, :currency).find(params[:id])
 
-        render json: transaction, status: :ok
+        render_jsonapi_response(transaction, include: [ :category, :currency ])
     end
 
     def create
         service = TransactionCreateService.new(current_user, transaction_params)
 
-        render json: service.call, status: :created
+        render_jsonapi_response(service.call, include: [ :category, :currency ], status: :created)
     end
 
     def update
         transaction = current_user.transactions.find(params[:id])
         service = TransactionUpdateService.new(transaction, transaction_params)
 
-        render json: service.call, status: :ok
+        render_jsonapi_response(service.call, include: [ :category, :currency ])
     end
 
     def destroy
@@ -43,11 +43,11 @@ class TransactionsController < ApplicationController
     private
 
     def render_not_found(exception)
-        render json: { error: exception.message }, status: :not_found
+        render_jsonapi_error(exception.message, status: :not_found)
     end
 
     def render_unprocessable_content(exception)
-        render json: { error: exception.record.errors.full_messages }, status: :unprocessable_content
+        render_jsonapi_error(exception.record.errors.full_messages, status: :unprocessable_content)
     end
 
     def parse_sort_params(param)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,13 +6,13 @@ class UsersController < ApplicationController
     def index
         users = User.all
 
-        render json: users, status: :ok
+        render_jsonapi_response(users)
     end
 
     def show
         user = User.find(params[:id])
 
-        render json: user, status: :ok
+        render_jsonapi_response(user)
     end
 
     def create
@@ -20,14 +20,14 @@ class UsersController < ApplicationController
         user.save!
         token = encode_token(user_id: user.id)
 
-        render json: { user: user, token: token }, status: :created
+        render_jsonapi_response(user, status: :created, meta: { token: token })
     end
 
     def update
         user = User.find(params[:id])
         user.update!(user_params)
 
-        render json: user, status: :ok
+        render_jsonapi_response(user)
     end
 
     def destroy
@@ -40,11 +40,11 @@ class UsersController < ApplicationController
     private
 
     def render_not_found(exception)
-        render json: { error: exception.message }, status: :not_found
+        render_jsonapi_error(exception.message, status: :not_found)
     end
 
     def render_unprocessable_content(exception)
-        render json: { error: exception.record.errors.full_messages }, status: :unprocessable_content
+        render_jsonapi_error(exception.record.errors.full_messages, status: :unprocessable_content)
     end
 
     def user_params

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,0 +1,10 @@
+class CategorySerializer
+  include JSONAPI::Serializer
+
+  attributes :name
+  attributes :user_id
+  attributes :parent_id
+  attributes :category_type
+  attributes :updated_at
+  attributes :created_at
+end

--- a/app/serializers/currency_serializer.rb
+++ b/app/serializers/currency_serializer.rb
@@ -1,0 +1,9 @@
+class CurrencySerializer
+  include JSONAPI::Serializer
+
+  attributes :code
+  attributes :name
+  attributes :decimal_places
+  attributes :updated_at
+  attributes :created_at
+end

--- a/app/serializers/default_serializer.rb
+++ b/app/serializers/default_serializer.rb
@@ -1,0 +1,4 @@
+class DefaultSerializer
+  include JSONAPI::Serializer
+  # This serializer is intended for cases where an empty data collection needs to be processed.
+end

--- a/app/serializers/scheduled_transaction_serializer.rb
+++ b/app/serializers/scheduled_transaction_serializer.rb
@@ -1,0 +1,19 @@
+class ScheduledTransactionSerializer
+  include JSONAPI::Serializer
+
+  belongs_to :category
+  belongs_to :currency
+
+  attributes :user_id
+  attributes :category_id
+  attributes :currency_id
+  attributes :amount
+  attributes :frequency
+  attributes :day_of_week
+  attributes :day_of_month
+  attributes :start_date
+  attributes :next_execute_at
+  attributes :active
+  attributes :updated_at
+  attributes :created_at
+end

--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -1,6 +1,15 @@
-class TransactionSerializer < ActiveModel::Serializer
-  attributes :id, :user_id, :amount, :description, :transaction_date, :created_at, :updated_at
+class TransactionSerializer
+  include JSONAPI::Serializer
 
   belongs_to :category
   belongs_to :currency
+
+  attributes :amount
+  attributes :user_id
+  attributes :category_id
+  attributes :currency_id
+  attributes :description
+  attributes :transaction_date
+  attributes :updated_at
+  attributes :created_at
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,9 @@
+class UserSerializer
+  include JSONAPI::Serializer
+
+  attributes :name
+  attributes :email
+  attributes :balance
+  attributes :updated_at
+  attributes :created_at
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:3002"
+    origins "http://localhost:3001"
 
     resource "*",
       headers: :any,

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Auths", type: :request do
       it "returns unauthorized" do
         post AUTH_URL, params: { auth: { email: user.email,  password: 'wrongpass' } }
 
-        expect(response.parsed_body['message']).to eq('Incorrect password')
+        expect(response.parsed_body["errors"][0]["detail"]).to eq('Incorrect password')
       end
     end
 

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -2,7 +2,11 @@ require 'rails_helper'
 
 CATEGORIES_URL = "/api/v1/categories".freeze
 
-RSpec.describe "Categories", type: :request do
+DEFAULT_CATEGORIES_SIZE = 3
+CURRENT_USER_CATEGORIES_SIZE = 3
+OTHER_USER_CATEGORIES_SIZE = 2
+
+RSpec.describe 'Categories', type: :request do
   let(:current_user) { create(:auth_user) }
   let(:token) { JWT.encode({ user_id: current_user.id }, Rails.application.secret_key_base) }
   let(:headers) { { 'Authorization' => "Bearer #{token}" } }
@@ -10,73 +14,73 @@ RSpec.describe "Categories", type: :request do
   let(:other_user) { create(:dynamic_user) }
 
   def json_response
-    response.parsed_body
+    response.parsed_body[:data]
   end
 
-  describe "GET /categories" do
+  describe 'GET /categories' do
     before do
-      create_list(:dynamic_category, 3, user: current_user)
-      create_list(:dynamic_category, 2, user: other_user)
+      create_list(:dynamic_category, CURRENT_USER_CATEGORIES_SIZE, user: current_user)
+      create_list(:dynamic_category, OTHER_USER_CATEGORIES_SIZE, user: other_user)
     end
 
-    it "returns status ok" do
+    it 'returns status ok' do
       get CATEGORIES_URL, headers: headers
 
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns all categories belonging to current_user" do
+    it 'returns all categories belonging to current_user' do
       get CATEGORIES_URL, headers: headers
 
-      expect(json_response.size).to eq(3)
-      expect(json_response.all? { |t| t["user_id"] == current_user.id }).to be true
+      expect(json_response.size).to eq(CURRENT_USER_CATEGORIES_SIZE)
+      expect(json_response.all? { |t| t['attributes']['user_id'] == current_user.id }).to be true
     end
 
-    it "returns all categories belonging to current_user + default with user equal nil" do
-      create_list(:category, 5) # with no user
+    it 'returns all categories belonging to current_user + default with user equal nil' do
+      create_list(:category, DEFAULT_CATEGORIES_SIZE) # with no user
       get CATEGORIES_URL, headers: headers
 
-      expect(json_response.size).to eq(3 + 5)
-      end
+      expect(json_response.size).to eq(CURRENT_USER_CATEGORIES_SIZE + DEFAULT_CATEGORIES_SIZE)
     end
+  end
 
-  describe "GET /categories/:id" do
+  describe 'GET /categories/:id' do
     let!(:current_user_category) { create(:dynamic_category, user: current_user) }
     let!(:other_user_category) { create(:dynamic_category, user: other_user) }
 
-    it "returns the category if it belongs to the user" do
-      get CATEGORIES_URL + "/#{current_user_category.id}", headers: headers
+    it 'returns the category if it belongs to the user' do
+      get "#{CATEGORIES_URL}/#{current_user_category.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(json_response["id"]).to eq(current_user_category.id)
+      expect(json_response['id'].to_i).to eq(current_user_category.id)
     end
 
-    it "returns 404 if the category does not belong to the user" do
-      get CATEGORIES_URL + "/#{other_user_category.id}", headers: headers
+    it 'returns 404 if the category does not belong to the user' do
+      get "#{CATEGORIES_URL}/#{other_user_category.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /categories" do
+  describe 'POST /categories' do
     let!(:parent_category) { create(:dynamic_category, user: current_user) }
     let(:valid_params) do
     {
       category: {
         parent_id: parent_category.id,
-        name: "Valid name",
+        name: 'Valid name',
         category_type: parent_category.category_type
       }
     }
     end
 
-    it "creates the category belonging to current user" do
+    it 'creates the category belonging to current user' do
       expect {
         post CATEGORIES_URL, params: valid_params, headers: headers
       }.to change(Category, :count).by(1)
 
       expect(response).to have_http_status(:created)
-      expect(json_response["user_id"]).to eq(current_user.id)
+      expect(json_response['attributes']['user_id']).to eq(current_user.id)
     end
 
     it 'returns unprocessable_content for not existing record' do
@@ -84,27 +88,27 @@ RSpec.describe "Categories", type: :request do
       post CATEGORIES_URL, params: invalid_params, headers: headers
 
       expect(response).to have_http_status(:unprocessable_content)
-      expect(json_response["error"]).to be_present
     end
 
     it 'returns unprocessable_content for invalid data' do
-      invalid_params = { category: { name: "", category_type: "invalid_type" } }
+      invalid_params = { category: { name: '', category_type: 'invalid_type' } }
       post CATEGORIES_URL, params: invalid_params, headers: headers
 
       expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors']).to be_present
     end
 
-  it 'returns unprocessable_content for data when parent_id category assigned to antoher user' do
-      other_user_category = create(:dynamic_category, user: other_user)
-      forbidden_params = valid_params
-      forbidden_params[:category][:parent_id] = other_user_category.id
-      post '/api/v1/categories', params: forbidden_params, headers: headers
+    it 'returns unprocessable_content for data when parent_id category assigned to antoher user' do
+        other_user_category = create(:dynamic_category, user: other_user)
+        forbidden_params = valid_params
+        forbidden_params[:category][:parent_id] = other_user_category.id
+        post '/api/v1/categories', params: forbidden_params, headers: headers
 
-      expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
-  describe "PUT /categories/:id" do
+  describe 'PUT /categories/:id' do
     let!(:parent_category) { create(:dynamic_category, user: current_user) }
     let!(:current_user_category) { create(:dynamic_category, user: current_user) }
     let!(:other_user_category) { create(:dynamic_category, user: other_user) }
@@ -112,41 +116,41 @@ RSpec.describe "Categories", type: :request do
     {
       category: {
         parent_id: parent_category.id,
-        name: "Valid name",
+        name: 'Valid name',
         category_type: parent_category.category_type
       }
     }
     end
 
-    it "updates a category for current_user" do
-      put CATEGORIES_URL + "/#{current_user_category.id}", params: valid_update_params, headers: headers
+    it 'updates a category for current_user' do
+      put "#{CATEGORIES_URL}/#{current_user_category.id}", params: valid_update_params, headers: headers
       current_user_category.reload
 
       expect(response).to have_http_status(:ok)
       expect(current_user_category.parent.id).to eq(parent_category.id)
     end
 
-    it "returns 404 if category not owned" do
-      put CATEGORIES_URL + "/#{other_user_category.id}", params: valid_update_params, headers: headers
+    it 'returns 404 if category not owned' do
+      put "#{CATEGORIES_URL}/#{other_user_category.id}", params: valid_update_params, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /categories/:id" do
+  describe 'DELETE /categories/:id' do
     let!(:current_user_category) { create(:dynamic_category, user: current_user) }
     let!(:other_user_category) { create(:dynamic_category, user: other_user) }
 
-    it "deletes current_user's category" do
+    it 'deletes current_user\'s category' do
       expect {
-        delete CATEGORIES_URL + "/#{current_user_category.id}", headers: headers
+        delete "#{CATEGORIES_URL}/#{current_user_category.id}", headers: headers
       }.to change(Category, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
-    it "returns 404 for unauthorized category" do
-      delete CATEGORIES_URL + "/#{other_user_category.id}", headers: headers
+    it 'returns 404 for unauthorized category' do
+      delete "#{CATEGORIES_URL}/#{other_user_category.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/currencies_spec.rb
+++ b/spec/requests/currencies_spec.rb
@@ -2,64 +2,66 @@ require 'rails_helper'
 
 CURRENCY_URL = "/api/v1/currencies".freeze
 
-RSpec.describe "Currencies", type: :request do
+CURRENCIES_SIZE = 3
+
+RSpec.describe 'Currencies', type: :request do
   let(:user) { create(:user) }
   let(:token) { JWT.encode({ user_id: user.id }, Rails.application.secret_key_base) }
   let(:headers) { { 'Authorization' => "Bearer #{token}" } }
 
   def json_response
-    response.parsed_body
+    response.parsed_body[:data]
   end
 
-  describe "GET /currencies" do
+  describe 'GET /currencies' do
     before do
-      create_list(:dynamic_currency, 3)
+      create_list(:dynamic_currency, CURRENCIES_SIZE)
     end
 
-    it "returns status ok" do
+    it 'returns status ok' do
       get CURRENCY_URL, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body.size).to eq(3)
+      expect(json_response.size).to eq(CURRENCIES_SIZE)
     end
   end
 
-  describe "GET /currencies/:id" do
+  describe 'GET /currencies/:id' do
     let!(:get_currency) { create(:dynamic_currency) }
 
-    it "returns status ok" do
-      get CURRENCY_URL + "/#{get_currency.id}", headers: headers
+    it 'returns status ok' do
+      get "#{CURRENCY_URL}/#{get_currency.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(json_response["id"]).to eq(get_currency.id)
+      expect(json_response['id'].to_i).to eq(get_currency.id)
     end
 
-    it "returns 404 if the currency does not exist" do
-      get CURRENCY_URL + "/#{0}", headers: headers
+    it 'returns 404 if the currency does not exist' do
+      get "#{CURRENCY_URL}/#{0}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /currencies" do
+  describe 'POST /currencies' do
     let(:valid_params) do
       {
         currency: {
-          code: "Valid code",
-          name: "Valid name",
+          code: 'Valid code',
+          name: 'Valid name',
           decimal_places: 2
         }
       }
     end
 
-    it "returns status created" do
+    it 'returns status created' do
       post CURRENCY_URL, params: valid_params, headers: headers
 
       expect(response).to have_http_status(:created)
-      expect(json_response["name"]).to eq(valid_params[:currency][:name])
+      expect(json_response['attributes']['name']).to eq(valid_params[:currency][:name])
     end
 
-    it "returns errors for invalid data" do
+    it 'returns errors for invalid data' do
       invalid_params = { currency: { code: nil, decimal_places: -2 } }
       post CURRENCY_URL, params: invalid_params, headers: headers
 
@@ -67,45 +69,45 @@ RSpec.describe "Currencies", type: :request do
     end
   end
 
-  describe "PUT /currencies" do
+  describe 'PUT /currencies' do
     let!(:get_currency) { create(:dynamic_currency) }
     let(:valid_params) do
       {
         currency: {
-          code: "Valid code",
-          name: "Valid name",
+          code: 'Valid code',
+          name: 'Valid name',
           decimal_places: 2
         }
       }
     end
 
-    it "returns status ok" do
-      put CURRENCY_URL + "/#{get_currency.id}", params: valid_params, headers: headers
+    it 'returns status ok' do
+      put "#{CURRENCY_URL}/#{get_currency.id}", params: valid_params, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(json_response["id"]).to eq(get_currency.id)
+      expect(json_response['id'].to_i).to eq(get_currency.id)
     end
 
-    it "returns errors for invalid id" do
-      put CURRENCY_URL + "/#{0}", params: valid_params, headers: headers
+    it 'returns errors for invalid id' do
+      put "#{CURRENCY_URL}/#{0}", params: valid_params, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /currencies/:id" do
+  describe 'DELETE /currencies/:id' do
     let!(:get_currency) { create(:dynamic_currency) }
 
-    it "deletes currency" do
+    it 'deletes currency' do
       expect {
-        delete CURRENCY_URL + "/#{get_currency.id}", headers: headers
+        delete "#{CURRENCY_URL}/#{get_currency.id}", headers: headers
       }.to change(Currency, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
-    it "returns 404 errors for invalid data" do
-      delete CURRENCY_URL + "/#{0}", headers: headers
+    it 'returns 404 errors for invalid data' do
+      delete "#{CURRENCY_URL}/#{0}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/scheduled_transactions_spec.rb
+++ b/spec/requests/scheduled_transactions_spec.rb
@@ -2,134 +2,137 @@ require 'rails_helper'
 
 SCHEDULED_TRANSACTION_URL = "/api/v1/scheduled_transactions".freeze
 
-RSpec.describe "ScheduledTransactions", type: :request do
-    let(:current_user) { create(:auth_user) }
-    let(:token) { JWT.encode({ user_id: current_user.id }, Rails.application.secret_key_base) }
-    let(:headers) { { 'Authorization' => "Bearer #{token}" } }
-    let(:other_user) { create(:dynamic_user) }
+CURRENT_USER_SCHEDULED_TRANSACTIONS_SIZE = 3
+OTHER_USER_SCHEDULED_TRANSACTIONS_SIZE = 2
 
-    def json_response
-        response.parsed_body
+RSpec.describe 'ScheduledTransactions', type: :request do
+  let(:current_user) { create(:auth_user) }
+  let(:token) { JWT.encode({ user_id: current_user.id }, Rails.application.secret_key_base) }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+  let(:other_user) { create(:dynamic_user) }
+
+  def json_response
+    response.parsed_body[:data]
+  end
+
+  describe 'GET /scheduled_transactions' do
+    before do
+      create_list(:scheduled_transaction, CURRENT_USER_SCHEDULED_TRANSACTIONS_SIZE, user: current_user)
+      create_list(:scheduled_transaction, OTHER_USER_SCHEDULED_TRANSACTIONS_SIZE, user: other_user)
     end
 
-    describe "GET /scheduled_transactions" do
-      before do
-        create_list(:scheduled_transaction, 3, user: current_user)
-        create_list(:scheduled_transaction, 2, user: other_user)
-      end
+    it 'returns status ok' do
+      get SCHEDULED_TRANSACTION_URL, headers: headers
 
-      it "returns status ok" do
-        get SCHEDULED_TRANSACTION_URL, headers: headers
-
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "returns all categories belonging to current_user" do
-        get SCHEDULED_TRANSACTION_URL, headers: headers
-
-        expect(json_response.size).to eq(3)
-        expect(json_response.all? { |t| t["user_id"] == current_user.id }).to be true
-      end
+      expect(response).to have_http_status(:ok)
     end
 
-    describe "GET /scheduled_transactions/:id" do
-      let!(:current_user_scheduled_transaction) { create(:scheduled_transaction, user: current_user) }
-      let!(:other_user_scheduled_transaction) { create(:scheduled_transaction, user: other_user) }
+    it 'returns all categories belonging to current_user' do
+      get SCHEDULED_TRANSACTION_URL, headers: headers
 
-      it "returns the category if it belongs to the user" do
-        get SCHEDULED_TRANSACTION_URL + "/#{current_user_scheduled_transaction.id}", headers: headers
+      expect(json_response.size).to eq(CURRENT_USER_SCHEDULED_TRANSACTIONS_SIZE)
+      expect(json_response.all? { |t| t['attributes']['user_id'] == current_user.id }).to be true
+    end
+  end
 
-        expect(response).to have_http_status(:ok)
-        expect(json_response["id"]).to eq(current_user_scheduled_transaction.id)
-      end
+  describe 'GET /scheduled_transactions/:id' do
+    let!(:current_user_scheduled_transaction) { create(:scheduled_transaction, user: current_user) }
+    let!(:other_user_scheduled_transaction) { create(:scheduled_transaction, user: other_user) }
 
-      it "returns 404 if the category does not belong to the user" do
-        get SCHEDULED_TRANSACTION_URL + "/#{other_user_scheduled_transaction.id}", headers: headers
+    it 'returns the category if it belongs to the user' do
+      get "#{SCHEDULED_TRANSACTION_URL}/#{current_user_scheduled_transaction.id}", headers: headers
 
-        expect(response).to have_http_status(:not_found)
-      end
+      expect(response).to have_http_status(:ok)
+      expect(json_response['id'].to_i).to eq(current_user_scheduled_transaction.id)
     end
 
-    describe "POST /scheduled_transactions" do
-      let(:valid_params) do
-      {
-        scheduled_transaction: {
-          category_id: create(:category).id,
-          currency_id: create(:currency).id,
-          amount: 100,
-          description: "valid desctiption",
-          frequency: "weekly",
-          day_of_week: 3,
-          start_date: 1.day.from_now
-        }
+    it 'returns 404 if the category does not belong to the user' do
+      get "#{SCHEDULED_TRANSACTION_URL}/#{other_user_scheduled_transaction.id}", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /scheduled_transactions' do
+    let(:valid_params) do
+    {
+      scheduled_transaction: {
+        category_id: create(:category).id,
+        currency_id: create(:currency).id,
+        amount: 100,
+        description: 'valid desctiption',
+        frequency: 'weekly',
+        day_of_week: 3,
+        start_date: 1.day.from_now
       }
-      end
-
-      it "creates the category belonging to current user" do
-        expect {
-          post SCHEDULED_TRANSACTION_URL, params: valid_params, headers: headers
-        }.to change(ScheduledTransaction, :count).by(1)
-
-        expect(response).to have_http_status(:created)
-        expect(json_response["user_id"]).to eq(current_user.id)
-      end
-
-      it 'returns errors for invalid data' do
-        invalid_params = { scheduled_transaction: { category_id: 0 } }
-        post SCHEDULED_TRANSACTION_URL, params: invalid_params, headers: headers
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(json_response["error"]).to be_present
-      end
+    }
     end
 
-    describe "PUT /scheduled_transactions/:id" do
-      let!(:current_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: current_user) }
-      let!(:other_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: other_user) }
-      let(:valid_update_params) do
-      {
-        scheduled_transaction: {
-          category_id: create(:category).id,
-          currency_id: create(:currency).id,
-          amount: 100,
-          description: "valid desctiption",
-          frequency: "monthly",
-          day_of_month: 23,
-          start_date: 1.day.from_now
-        }
+    it 'creates the category belonging to current user' do
+      expect {
+        post SCHEDULED_TRANSACTION_URL, params: valid_params, headers: headers
+      }.to change(ScheduledTransaction, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(json_response['attributes']['user_id']).to eq(current_user.id)
+    end
+
+    it 'returns errors for invalid data' do
+      invalid_params = { scheduled_transaction: { category_id: 0 } }
+      post SCHEDULED_TRANSACTION_URL, params: invalid_params, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors']).to be_present
+    end
+  end
+
+  describe 'PUT /scheduled_transactions/:id' do
+    let!(:current_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: current_user) }
+    let!(:other_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: other_user) }
+    let(:valid_update_params) do
+    {
+      scheduled_transaction: {
+        category_id: create(:category).id,
+        currency_id: create(:currency).id,
+        amount: 100,
+        description: 'valid desctiption',
+        frequency: 'monthly',
+        day_of_month: 23,
+        start_date: 1.day.from_now
       }
-      end
-
-      it "updates a category for current_user" do
-        put SCHEDULED_TRANSACTION_URL + "/#{current_user_scheduled_transaction.id}", params: valid_update_params, headers: headers
-        current_user_scheduled_transaction.reload
-
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "returns 404 if category not owned" do
-        put "/scheduled_transactions/#{other_user_scheduled_transaction.id}", params: valid_update_params, headers: headers
-
-        expect(response).to have_http_status(:not_found)
-      end
+    }
     end
 
-    describe "DELETE /scheduled_transactions/:id" do
-      let!(:current_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: current_user) }
-      let!(:other_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: other_user) }
+    it 'updates a category for current_user' do
+      put "#{SCHEDULED_TRANSACTION_URL}/#{current_user_scheduled_transaction.id}", params: valid_update_params, headers: headers
+      current_user_scheduled_transaction.reload
 
-      it "deletes current_user's scheduled_transactions" do
-        expect {
-          delete SCHEDULED_TRANSACTION_URL + "/#{current_user_scheduled_transaction.id}", headers: headers
-        }.to change(ScheduledTransaction, :count).by(-1)
-
-        expect(response).to have_http_status(:no_content)
-      end
-
-      it "returns 404 for unauthorized category" do
-        delete SCHEDULED_TRANSACTION_URL + "/#{other_user_scheduled_transaction.id}", headers: headers
-
-        expect(response).to have_http_status(:not_found)
-      end
+      expect(response).to have_http_status(:ok)
     end
+
+    it 'returns 404 if category not owned' do
+      put "#{SCHEDULED_TRANSACTION_URL}/#{other_user_scheduled_transaction.id}", params: valid_update_params, headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'DELETE /scheduled_transactions/:id' do
+    let!(:current_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: current_user) }
+    let!(:other_user_scheduled_transaction) { create(:scheduled_transaction, :weekly, day_of_week: 3, user: other_user) }
+
+    it 'deletes current_user\'s scheduled_transactions' do
+      expect {
+        delete "#{SCHEDULED_TRANSACTION_URL}/#{current_user_scheduled_transaction.id}", headers: headers
+      }.to change(ScheduledTransaction, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 404 for unauthorized category' do
+      delete "#{SCHEDULED_TRANSACTION_URL}/#{other_user_scheduled_transaction.id}", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 TRANSACTION_URL = "/api/v1/transactions".freeze
 
-RSpec.describe "Transactions", type: :request do
+CURRENT_USER_TRANSACTIONS_SIZE = 3
+OTHER_USER_TRNASACTIONS_SIZE = 2
+
+RSpec.describe 'Transactions', type: :request do
   let(:auth_user) { create(:auth_user) }
   let(:token) { JWT.encode({ user_id: auth_user.id }, Rails.application.secret_key_base) }
   let(:headers) { { 'Authorization' => "Bearer #{token}" } }
@@ -13,48 +16,48 @@ RSpec.describe "Transactions", type: :request do
   let(:other_user) { create(:dynamic_user) }
 
   before do
-    create_list(:dynamic_transaction, 3, user: current_user)
-    create_list(:dynamic_transaction, 2, user: other_user)
+    create_list(:dynamic_transaction, CURRENT_USER_TRANSACTIONS_SIZE, user: current_user)
+    create_list(:dynamic_transaction, OTHER_USER_TRNASACTIONS_SIZE, user: other_user)
   end
 
   def json_response
-    response.parsed_body
+    response.parsed_body[:data]
   end
 
-  describe "GET /transactions" do
-    it "returns status ok" do
+  describe 'GET /transactions' do
+    it 'returns status ok' do
       get TRANSACTION_URL, headers: headers
 
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns only transactions belonging to current user" do
+    it 'returns only transactions belonging to current user' do
       get TRANSACTION_URL, headers: headers
 
-      expect(json_response.size).to eq(3)
-      expect(json_response.all? { |t| t["user_id"] == auth_user.id }).to be true
+      expect(json_response.size).to eq(CURRENT_USER_TRANSACTIONS_SIZE)
+      expect(json_response.all? { |t| t['attributes']['user_id'] == auth_user.id }).to be true
     end
   end
 
-  describe "GET /transactions/:id" do
+  describe 'GET /transactions/:id' do
     let!(:transaction) { create(:dynamic_transaction, user: current_user) }
     let!(:other_transaction) { create(:dynamic_transaction, user: other_user) }
 
-    it "returns the transaction if it belongs to the user" do
-      get TRANSACTION_URL + "/#{transaction.id}", headers: headers
+    it 'returns the transaction if it belongs to the user' do
+      get "#{TRANSACTION_URL}/#{transaction.id}", headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(json_response["id"]).to eq(transaction.id)
+      expect(json_response['id'].to_i).to eq(transaction.id)
     end
 
-    it "returns 404 if the transaction does not belong to the user" do
-      get TRANSACTION_URL + "/#{other_transaction.id}", headers: headers
+    it 'returns 404 if the transaction does not belong to the user' do
+      get "#{TRANSACTION_URL}/#{other_transaction.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /transactions" do
+  describe 'POST /transactions' do
     let(:valid_params) do
     {
       transaction: {
@@ -67,13 +70,13 @@ RSpec.describe "Transactions", type: :request do
     }
     end
 
-    it "creates the transaction belonging to current user" do
+    it 'creates the transaction belonging to current user' do
       expect {
         post TRANSACTION_URL, params: valid_params, headers: headers
       }.to change(Transaction, :count).by(1)
 
       expect(response).to have_http_status(:created)
-      expect(json_response["user_id"]).to eq(auth_user.id)
+      expect(json_response['attributes']['user_id']).to eq(auth_user.id)
     end
 
     it 'returns errors for invalid data' do
@@ -81,11 +84,11 @@ RSpec.describe "Transactions", type: :request do
       post TRANSACTION_URL, params: invalid_params, headers: headers
 
       expect(response).to have_http_status(:unprocessable_content)
-      expect(json_response["error"]).to be_present
+      expect(response.parsed_body['errors']).to be_present
     end
   end
 
-  describe "PUT /transactions/:id" do
+  describe 'PUT /transactions/:id' do
     let!(:transaction) { create(:transaction, user: current_user, category: category, currency: currency, amount: 100) }
     let!(:other_transaction) { create(:transaction, user: other_user, category: category, currency: currency, amount: 100) }
     let(:update_params) do
@@ -94,34 +97,34 @@ RSpec.describe "Transactions", type: :request do
       }
     end
 
-    it "updates a transaction for current_user" do
-      put TRANSACTION_URL + "/#{transaction.id}", params: update_params, headers: headers
+    it 'updates a transaction for current_user' do
+      put "#{TRANSACTION_URL}/#{transaction.id}", params: update_params, headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(transaction.reload.amount).to eq(75)
     end
 
-    it "returns 404 if transaction not owned" do
-      put TRANSACTION_URL + "/#{other_transaction.id}", params: update_params, headers: headers
+    it 'returns 404 if transaction not owned' do
+      put "#{TRANSACTION_URL}/#{other_transaction.id}", params: update_params, headers: headers
 
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "DELETE /transactions/:id" do
+  describe 'DELETE /transactions/:id' do
     let!(:transaction) { create(:transaction, user: current_user, category: category, currency: currency, amount: 100) }
     let!(:other_transaction) { create(:transaction, user: other_user, category: category, currency: currency, amount: 100) }
 
-    it "deletes current_user's transaction" do
+    it 'deletes current_user\'s transaction' do
       expect {
-        delete TRANSACTION_URL + "/#{transaction.id}", headers: headers
+        delete "#{TRANSACTION_URL}/#{transaction.id}", headers: headers
       }.to change(Transaction, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
 
-    it "returns 404 for unauthorized transaction" do
-      delete TRANSACTION_URL + "/#{other_transaction.id}", headers: headers
+    it 'returns 404 for unauthorized transaction' do
+      delete "#{TRANSACTION_URL}/#{other_transaction.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Users", type: :request do
   end
 
   def json_response
-    response.parsed_body
+    response.parsed_body[:data]
   end
 
   describe "GET /users" do


### PR DESCRIPTION
Added `jsonapi-serializer` gem with methods: `render_jsonapi_response` and `render_jsonapi_error` for correct formatting every responses according [JSON_API format](https://jsonapi.org/format/). 
Method `serializer_for` is a helper method to automatically indicates the serializer class for the collection in the response.

Link to Trello task: https://trello.com/c/Kh12BI2e/30-response-json-api-format